### PR TITLE
Added here-objects

### DIFF
--- a/plan
+++ b/plan
@@ -5,11 +5,26 @@ These classes are generally referred to with their lowercase inital letter (t, c
 Objects are instances of these classes, which are stored in files.
 
 In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a (short) description.
-When declaring a here-object, the object-name is fully defined in the complete document.
-The syntax is [<class-letter>/<name>; <description>].
+The syntax is `[<class-letter>/<name>; <description>]`.
 
 For example:
-[t/Screen; Provides functions for rendering to the screen]
+`[t/Screen; Provides functions for rendering to the screen]`
+
+or multiline:
+[t/Screen;
+	Concepts: "c/SomeConcept"
+
+	# Description
+	Provides functions for rendering to the screen
+]
+
+When declaring a here-object, the object-name is fully defined in the complete document.
+When needing to refer to a here-object from another document, it's necesarry to first name the parent-object:
+`<parent-class-letter>/<parent-name>/<class-letter>/<name>`
+
+For example:
+`c/Screen/t/Screen` if the task t/Screen is defined in c/Screen.
+
 
 /		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
 /root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"

--- a/plan
+++ b/plan
@@ -1,7 +1,17 @@
 # plan
 
-/		Contains c,t,p,i,b-folders which contain all concepts/tasks/problems/implementations/bugs. Every Task with name <name> is stored as the file /t/<name> and so on...
-/root: 		The project will be defined here. In addition to the Task-Template it containes "Ideas" and a "Begin Date"
+Classes are Task, Concept, Bug, Problem and Implementation.
+These classes are generally referred to with their lowercase inital letter (t, c, b, p, i).
+Objects are instances of these classes, which are stored in files.
+
+In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a TL;DR.
+The syntax is [<class-letter>/<name> "<TL;DR>"].
+
+For example:
+[t/Screen "Provides functions for rendering to the screen."]
+
+/		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
+/root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"
 
 Task:
 	A "task" describes what has to be done, NOT how to do it.
@@ -43,7 +53,6 @@ Implementation:
 	Close to "concept", but without any subtasks, and therefore very detailed, with snippets from header-files.
 
 	Header/Class-Diagram:	A way to represent the implementation
-
 
 # TODO excludes: "Some concepts/implementations explicitly exclude some things -- as a generic parameter in class C, prevents using a List<C>"
 # TODO tags

--- a/plan
+++ b/plan
@@ -5,11 +5,10 @@ These classes are generally referred to with their lowercase inital letter (t, c
 Objects are instances of these classes, which are stored in files.
 
 In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a (short) description.
-When declaring a here-object, the object-name is fully defined in the complete document.
-The syntax is [<class-letter>/<name>; <description>].
+The syntax is [<class-letter>/<name>: <description>].
 
 For example:
-[t/Screen; Provides functions for rendering to the screen]
+[t/Screen: Provides functions for rendering to the screen]
 
 /		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
 /root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"

--- a/plan
+++ b/plan
@@ -4,11 +4,11 @@ Classes are Task, Concept, Bug, Problem and Implementation.
 These classes are generally referred to with their lowercase inital letter (t, c, b, p, i).
 Objects are instances of these classes, which are stored in files.
 
-In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a TL;DR.
-The syntax is [<class-letter>/<name> "<TL;DR>"].
+In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a (short) description.
+The syntax is [<class-letter>/<name>: <description>].
 
 For example:
-[t/Screen "Provides functions for rendering to the screen."]
+[t/Screen: Provides functions for rendering to the screen]
 
 /		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
 /root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"

--- a/plan
+++ b/plan
@@ -5,26 +5,11 @@ These classes are generally referred to with their lowercase inital letter (t, c
 Objects are instances of these classes, which are stored in files.
 
 In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a (short) description.
-The syntax is `[<class-letter>/<name>; <description>]`.
-
-For example:
-`[t/Screen; Provides functions for rendering to the screen]`
-
-or multiline:
-[t/Screen;
-	Concepts: "c/SomeConcept"
-
-	# Description
-	Provides functions for rendering to the screen
-]
-
 When declaring a here-object, the object-name is fully defined in the complete document.
-When needing to refer to a here-object from another document, it's necesarry to first name the parent-object:
-`<parent-class-letter>/<parent-name>/<class-letter>/<name>`
+The syntax is [<class-letter>/<name>; <description>].
 
 For example:
-`c/Screen/t/Screen` if the task t/Screen is defined in c/Screen.
-
+[t/Screen; Provides functions for rendering to the screen]
 
 /		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
 /root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"

--- a/plan
+++ b/plan
@@ -5,10 +5,11 @@ These classes are generally referred to with their lowercase inital letter (t, c
 Objects are instances of these classes, which are stored in files.
 
 In every object, you can put so-called here-objects, which allow you to create an object just by using a name and a (short) description.
-The syntax is [<class-letter>/<name>: <description>].
+When declaring a here-object, the object-name is fully defined in the complete document.
+The syntax is [<class-letter>/<name>; <description>].
 
 For example:
-[t/Screen: Provides functions for rendering to the screen]
+[t/Screen; Provides functions for rendering to the screen]
 
 /		Contains c,t,p,i,b-folders which contain all objects (of the particular class). Every Task with name <name> is stored as the file /t/<name> and so on...
 /root: 		The project will be defined here. In addition to the Task-Sample (see samples/t) it containes "Ideas" and a "Begin Date"


### PR DESCRIPTION
With here-objects you can orderly link to Objects which do not exist (yet), just by shortly declaring them.

The Syntax looks like the following:
`[t/Screen: an interface for rendering to the screen]` means, "The task, which cares for screen rendering".